### PR TITLE
[Automated] Standardize Ballerina.toml keywords

### DIFF
--- a/build-config/resources/Ballerina.toml
+++ b/build-config/resources/Ballerina.toml
@@ -5,7 +5,7 @@ name = "aws.redshift.driver"
 version = "@toml.version@"
 license = ["Apache-2.0"]
 authors = ["Ballerina"]
-keywords = ["Data Warehouse", "Cost/Paid", "Columnar Storage", "Vendor/Amazon", "Area/Communication", "Type/Driver"]
+keywords = ["Data Warehouse", "Cost/Paid", "Columnar Storage", "Vendor/AWS", "Area/Databases", "Type/Driver"]
 icon = "icon.png"
 repository = "https://github.com/ballerina-platform/module-ballerinax-aws.redshift.driver"
 

--- a/build-config/resources/Ballerina.toml
+++ b/build-config/resources/Ballerina.toml
@@ -5,7 +5,7 @@ name = "aws.redshift.driver"
 version = "@toml.version@"
 license = ["Apache-2.0"]
 authors = ["Ballerina"]
-keywords = ["Data Warehouse", "Cost/Paid", "Columnar Storage", "Vendor/AWS", "Area/Databases", "Type/Driver"]
+keywords = ["Data Warehouse", "Cost/Paid", "Columnar Storage", "Vendor/AWS", "Area/Database", "Type/Driver"]
 icon = "icon.png"
 repository = "https://github.com/ballerina-platform/module-ballerinax-aws.redshift.driver"
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Standardize package metadata keywords

Updated the package keywords in `build-config/resources/Ballerina.toml` to use standardized classification values:
- Changed vendor classification from "Amazon" to "AWS" for consistency with organizational naming standards
- Updated area classification from "Communication" to "Database" to accurately reflect the package's purpose as a database driver

These changes improve metadata clarity and ensure the package is correctly categorized in the package registry.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->